### PR TITLE
Fixed vars for RHEL 7 to work out of the box

### DIFF
--- a/vars/RedHat.yaml
+++ b/vars/RedHat.yaml
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 ---
-sshguard_config_items:
-  - whitelist
-
 sshguard_config_path: /etc
+
+# Full path to backend executable
+sshguard_backend: /usr/libexec/sshguard/sshg-fw-firewalld
+
+# Shell command that provides logs on standard output. Example: ssh and sendmail from systemd journal:
+sshguard_logreader: LANG=C /usr/bin/journalctl -afb -p info -n1 -t sshd -o cat


### PR DESCRIPTION
Added necessary vars for Red Hat, and removed one which was unnecessary
since it was already defined in defaults.